### PR TITLE
feat: add strict mode for return string format query param only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 node_js:
+- "iojs-1"
+- "0.12"
 - "0.11"
 language: node_js
 script: "npm run test-travis"
-after_script: "npm install coveralls@2.10.0 && cat ./coverage/lcov.info | coveralls"
+after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2014 Jonathan Ong me@jongleberry.com
+Copyright (c) 2015 koajs and other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,31 @@
-# Koa Querystring [![Build Status](https://travis-ci.org/koajs/qs.png)](https://travis-ci.org/koajs/qs)
+# Koa Querystring
 
-By default, Koa uses the native `querystring` module which does not provide nesting support. This patches a koa app with nesting support via the [qs](https://github.com/visionmedia/node-querystring) support, which is also used by Connect and Express.
+[![NPM version][npm-image]][npm-url]
+[![build status][travis-image]][travis-url]
+[![Test coverage][coveralls-image]][coveralls-url]
+[![David deps][david-image]][david-url]
+[![iojs version][iojs-image]][iojs-url]
+[![node version][node-image]][node-url]
+[![npm download][download-image]][download-url]
+
+[npm-image]: https://img.shields.io/npm/v/koa-qs.svg?style=flat-square
+[npm-url]: https://npmjs.org/package/koa-qs
+[travis-image]: https://img.shields.io/travis/koajs/qs.svg?style=flat-square
+[travis-url]: https://travis-ci.org/koajs/qs
+[coveralls-image]: https://img.shields.io/coveralls/koajs/qs.svg?style=flat-square
+[coveralls-url]: https://coveralls.io/r/koajs/qs?branch=master
+[david-image]: https://img.shields.io/david/koajs/qs.svg?style=flat-square
+[david-url]: https://david-dm.org/koajs/qs
+[iojs-image]: https://img.shields.io/badge/io.js-%3E=_1.0-yellow.svg?style=flat-square
+[iojs-url]: http://iojs.org/
+[node-image]: https://img.shields.io/badge/node.js-%3E=_0.11-green.svg?style=flat-square
+[node-url]: http://nodejs.org/download/
+[download-image]: https://img.shields.io/npm/dm/koa-qs.svg?style=flat-square
+[download-url]: https://npmjs.org/package/koa-qs
+
+By default, Koa uses the native `querystring` module which does not provide nesting support.
+This patches a koa app with nesting support via the [qs] support,
+which is also used by Connect and Express.
 
 Simply wrap a koa app with this module:
 
@@ -10,7 +35,7 @@ var app = koa()
 require('koa-qs')(app)
 ```
 
-Note that this module __does not include qs__. You need to install it on your own. This way, you don't have to worry about upgrading this module. Thus, your `package.json` should look something like this:
+Note that this module __does not include [qs]__. You need to install it on your own. This way, you don't have to worry about upgrading this module. Thus, your `package.json` should look something like this:
 
 ```json
 {
@@ -20,3 +45,58 @@ Note that this module __does not include qs__. You need to install it on your ow
   }
 }
 ```
+
+## Optional parse mode
+
+There're three parse mode.
+
+## `extended` mode
+
+The default mode, use [qs] module.
+
+```js
+require('koa-qs')(app, 'extended')
+```
+
+## `simple` mode
+
+Use `querystring` module, same as koa does by default.
+If you want to use this mode, don't use this module.
+
+## `strict` mode
+
+This mode make `this.query.foo` return strict `string`. Disable multi values.
+
+```js
+require('koa-qs')(app, 'strict')
+```
+
+In 95% use cases, application only want `string` query params.
+
+This patch can avoid some stupid `TypeError` and some security issues like [MongoDB inject](http://www.wooyun.org/bugs/wooyun-2010-086474)
+when the developers forget handling query params type check.
+
+#### What's different
+
+A normal request `GET /foo?p=a,b&p=b,c`.
+
+- before patch
+
+```js
+console.log('%j', this.query.p);
+["a,b", "b,c"]
+```
+
+- after patch
+
+```js
+console.log('%j', this.query.p);
+"a,b"
+```
+
+## License
+
+[MIT](LICENSE)
+
+
+[qs]: https://github.com/hapijs/qs

--- a/package.json
+++ b/package.json
@@ -11,26 +11,28 @@
   "license": "MIT",
   "repository": "koajs/qs",
   "dependencies": {
-    "merge-descriptors": "0.0.2"
+    "merge-descriptors": "~0.0.2"
   },
   "devDependencies": {
-    "istanbul-harmony": "0",
-    "qs": "*",
+    "istanbul-harmony": "*",
     "koa": "0",
     "mocha": "1",
+    "qs": "*",
     "should": "3",
-    "supertest": "0"
+    "supertest": "0",
+    "urllib": "~2.3.0"
   },
   "peerDependencies": {
     "qs": "*"
   },
   "scripts": {
-    "test": "NODE_ENV=test mocha --harmony-generators --require should --reporter spec",
-    "test-cov": "NODE_ENV=test node --harmony-generators ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --require should",
-    "test-travis": "NODE_ENV=test node --harmony-generators ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- --require should"
+    "test": "NODE_ENV=test mocha --harmony --require should --reporter spec",
+    "test-cov": "NODE_ENV=test node --harmony ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha -- --require should",
+    "test-travis": "NODE_ENV=test node --harmony ./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- --require should"
   },
   "engines": {
-    "node": ">= 0.11"
+    "node": ">= 0.11",
+    "iojs": ">= 1.0.0"
   },
   "files": [
     "index.js"


### PR DESCRIPTION
Fixes koajs/querystring-strict#1