### PR TITLE
Updates dependencies to fix NPM audit warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "repository": "koajs/qs",
   "dependencies": {
     "merge-descriptors": "~0.0.2",
-    "qs": "~2.3.3"
+    "qs": "~6.3.2"
   },
   "devDependencies": {
     "istanbul-harmony": "*",


### PR DESCRIPTION
Removes qs warnings from npm security audit report
```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Prototype Pollution Protection Bypass                        │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ qs                                                           │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ supertest [dev]                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ supertest > superagent > qs                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1469                            │
└───────────────┴──────────────────────────────────────────────────────────────┘

```